### PR TITLE
[AOS] feat: 채팅 목록 API 연동

### DIFF
--- a/dodamduck_aos/app/src/main/java/org/chosun/dodamduck/model/dto/ChatListResponse.kt
+++ b/dodamduck_aos/app/src/main/java/org/chosun/dodamduck/model/dto/ChatListResponse.kt
@@ -1,0 +1,18 @@
+package org.chosun.dodamduck.model.dto
+
+data class ChatListDTO(
+    val chat_id: String,
+    val user1_id: String,
+    val user2_id: String,
+    val last_message: String,
+    val last_message_timestamp: String,
+    val post_title: String,
+    val post_image_url: String,
+    val seller_profile_url: String,
+    val category: String
+)
+
+data class ChatListResponse(
+    val error: Boolean,
+    val chat_list: List<ChatListDTO>?
+)

--- a/dodamduck_aos/app/src/main/java/org/chosun/dodamduck/model/network/ChatApiService.kt
+++ b/dodamduck_aos/app/src/main/java/org/chosun/dodamduck/model/network/ChatApiService.kt
@@ -1,6 +1,7 @@
 package org.chosun.dodamduck.model.network
 
 import org.chosun.dodamduck.model.dto.ChatInfo
+import org.chosun.dodamduck.model.dto.ChatListResponse
 import retrofit2.http.Field
 import retrofit2.http.FormUrlEncoded
 import retrofit2.http.GET
@@ -21,4 +22,10 @@ interface ChatApiService {
         @Field("receiverID") receiver: String,
         @Field("message") message: String
     ): DodamDuckResponse
+
+
+    @GET("get_chat_list.php")
+    suspend fun getChatList(
+        @Query("user_id") user1: String
+    ): ChatListResponse?
 }

--- a/dodamduck_aos/app/src/main/java/org/chosun/dodamduck/model/repository/ChatRepository.kt
+++ b/dodamduck_aos/app/src/main/java/org/chosun/dodamduck/model/repository/ChatRepository.kt
@@ -1,13 +1,14 @@
 package org.chosun.dodamduck.model.repository
 
 import org.chosun.dodamduck.model.dto.ChatInfo
+import org.chosun.dodamduck.model.dto.ChatListDTO
 import org.chosun.dodamduck.model.network.ChatApiService
 import javax.inject.Inject
 
 class ChatRepository @Inject constructor(
     private val service: ChatApiService?
 ) {
-    suspend fun fetchChatList(
+    suspend fun fetchChats(
         user1: String,
         user2: String
     ): List<ChatInfo> {
@@ -20,5 +21,11 @@ class ChatRepository @Inject constructor(
         message: String
     ) {
         service?.sendChat(sender, receiver, message)
+    }
+
+    suspend fun fetchChatList(
+        userId: String
+    ): List<ChatListDTO> {
+        return service?.getChatList(userId)?.chat_list ?: listOf()
     }
 }

--- a/dodamduck_aos/app/src/main/java/org/chosun/dodamduck/model/viewmodel/ChatViewModel.kt
+++ b/dodamduck_aos/app/src/main/java/org/chosun/dodamduck/model/viewmodel/ChatViewModel.kt
@@ -7,6 +7,7 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.launch
 import org.chosun.dodamduck.model.dto.ChatInfo
+import org.chosun.dodamduck.model.dto.ChatListDTO
 import org.chosun.dodamduck.model.repository.ChatRepository
 import java.util.concurrent.Executors
 import java.util.concurrent.TimeUnit
@@ -17,17 +18,26 @@ class ChatViewModel @Inject constructor(
     private val repository: ChatRepository
 ) : ViewModel() {
 
-    private val _chatLists = MutableStateFlow<List<ChatInfo>?>(null)
-    val chatLists: StateFlow<List<ChatInfo>?> = _chatLists
+    private val _chats = MutableStateFlow<List<ChatInfo>?>(null)
+    val chats: StateFlow<List<ChatInfo>?> = _chats
+
+    private val _chatList = MutableStateFlow<List<ChatListDTO>?>(null)
+    val chatList: StateFlow<List<ChatListDTO>?> = _chatList
 
     private val scheduledExecutorService = Executors.newSingleThreadScheduledExecutor()
 
-    suspend fun getChatLists(user1: String, user2: String) {
+    suspend fun getChats(user1: String, user2: String) {
         scheduledExecutorService.scheduleAtFixedRate({
             viewModelScope.launch {
-                _chatLists.value = repository.fetchChatList(user1, user2)
+                _chats.value = repository.fetchChats(user1, user2)
             }
         }, 0, 1, TimeUnit.SECONDS)
+    }
+
+    suspend fun getChatList(userId: String) {
+        viewModelScope.launch {
+            _chatList.value = repository.fetchChatList(userId)
+        }
     }
 
     fun sendChat(

--- a/dodamduck_aos/app/src/main/java/org/chosun/dodamduck/ui/Chat.kt
+++ b/dodamduck_aos/app/src/main/java/org/chosun/dodamduck/ui/Chat.kt
@@ -30,9 +30,9 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.ContentScale
-import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
@@ -41,7 +41,7 @@ import androidx.compose.ui.unit.sp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.navigation.NavController
 import androidx.navigation.compose.rememberNavController
-import org.chosun.dodamduck.R
+import coil.compose.rememberAsyncImagePainter
 import org.chosun.dodamduck.model.viewmodel.ChatViewModel
 import org.chosun.dodamduck.ui.component.DodamDuckMessageInputField
 import org.chosun.dodamduck.ui.component.DodamDuckTextH2
@@ -52,12 +52,17 @@ import org.chosun.dodamduck.ui.theme.DodamDuckTheme
 @Composable
 fun ChatScreen(
     navController: NavController,
-    chatViewModel: ChatViewModel = hiltViewModel()
+    chatViewModel: ChatViewModel = hiltViewModel(),
+    currentUser: String = "",
+    otherUser: String = "",
+    postImageUrl: String = "",
+    postTitle: String = "",
+    category: String = ""
 ) {
-    val chatLists by chatViewModel.chatLists.collectAsState(initial = null)
+    val chats by chatViewModel.chats.collectAsState(initial = null)
 
     LaunchedEffect(Unit) {
-        chatViewModel.getChatLists("seyeong1", "seyeong2")
+        chatViewModel.getChats(currentUser, otherUser)
     }
 
     var message by remember { mutableStateOf("") }
@@ -69,7 +74,12 @@ fun ChatScreen(
     ) {
         Column {
             ChatScreenHeader(navController)
-            ChatItemInfo(modifier = Modifier.padding(start = 10.dp, top = 10.dp))
+            ChatItemInfo(
+                modifier = Modifier.padding(start = 10.dp, top = 10.dp),
+                postTitle = postTitle.replace("+", " "),
+                postImageUrl = postImageUrl,
+                category = category
+            )
             Divider(modifier = Modifier.padding(top = 10.dp, bottom = 5.dp))
             Text(
                 modifier = Modifier.align(Alignment.CenterHorizontally),
@@ -80,13 +90,14 @@ fun ChatScreen(
                 modifier = Modifier
                     .padding(horizontal = 12.dp, vertical = 12.dp)
                     .weight(1f),
-                list =  chatLists ?: listOf(),
-                currentUser = "seyeong1"
+                list = chats ?: listOf(),
+                currentUser = currentUser,
+                otherUser = otherUser
             )
 
             Divider()
             DodamDuckMessageInputField(
-                onSendButtonClick = { chatViewModel.sendChat("seyeong1", "seyeong2", message) },
+                onSendButtonClick = { chatViewModel.sendChat(currentUser, otherUser, message) },
                 onTextFieldChange = { message = it },
                 value = message
             )
@@ -124,7 +135,12 @@ fun ChatScreenHeader(navController: NavController) {
 }
 
 @Composable
-fun ChatItemInfo(modifier: Modifier = Modifier) {
+fun ChatItemInfo(
+    modifier: Modifier = Modifier,
+    postTitle: String,
+    postImageUrl: String,
+    category: String
+) {
     Column {
         Row(
             modifier = modifier
@@ -132,9 +148,10 @@ fun ChatItemInfo(modifier: Modifier = Modifier) {
             Image(
                 modifier = Modifier
                     .border(1.dp, Color.Gray, RoundedCornerShape(10.dp))
+                    .clip(RoundedCornerShape(10.dp))
                     .size(60.dp, 60.dp),
                 contentScale = ContentScale.Crop,
-                painter = painterResource(id = R.drawable.ic_duck),
+                painter = rememberAsyncImagePainter(postImageUrl),
                 contentDescription = "Exchange Item"
             )
 
@@ -146,9 +163,9 @@ fun ChatItemInfo(modifier: Modifier = Modifier) {
             ) {
                 Text(
                     modifier = Modifier.padding(bottom = 4.dp),
-                    text = "도담덕 봉제 인형", fontSize = 15.sp
+                    text = postTitle, fontSize = 15.sp
                 )
-                Text("5000원", fontSize = 15.sp)
+                Text(if(category == "1") "교환" else "나눔", fontSize = 15.sp)
             }
         }
 

--- a/dodamduck_aos/app/src/main/java/org/chosun/dodamduck/ui/component/lazy_components/ChatLazy.kt
+++ b/dodamduck_aos/app/src/main/java/org/chosun/dodamduck/ui/component/lazy_components/ChatLazy.kt
@@ -2,6 +2,8 @@ package org.chosun.dodamduck.ui.component.lazy_components
 
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.border
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -17,7 +19,6 @@ import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.Alignment.Companion.Bottom
-import androidx.compose.ui.Alignment.Companion.CenterVertically
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
@@ -77,16 +78,22 @@ fun ChatPartnerItem(
             contentDescription = "UserProfile"
         )
 
-        Surface(
-            modifier = Modifier.align(CenterVertically).wrapContentWidth().widthIn(max = 250.dp),
-            color = Color(0xFFEDEDED),
-            shape = RoundedCornerShape(40)
+        Column (
+            verticalArrangement = Arrangement.Center
         ) {
-            Text(
-                modifier = Modifier.padding(horizontal = 20.dp, vertical = 8.dp),
-                text = chatInfo.message
-            )
+            Text(modifier = Modifier.padding(bottom = 3.dp), text = otherUser)
+            Surface(
+                modifier = Modifier.wrapContentWidth().widthIn(max = 250.dp),
+                color = Color(0xFFEDEDED),
+                shape = RoundedCornerShape(40)
+            ) {
+                Text(
+                    modifier = Modifier.padding(horizontal = 20.dp, vertical = 8.dp),
+                    text = chatInfo.message
+                )
+            }
         }
+
         Text(
             modifier = Modifier
                 .align(Bottom)

--- a/dodamduck_aos/app/src/main/java/org/chosun/dodamduck/ui/component/lazy_components/ChatLazy.kt
+++ b/dodamduck_aos/app/src/main/java/org/chosun/dodamduck/ui/component/lazy_components/ChatLazy.kt
@@ -7,6 +7,8 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.widthIn
+import androidx.compose.foundation.layout.wrapContentWidth
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.shape.RoundedCornerShape
@@ -20,13 +22,13 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.ContentScale
-import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import org.chosun.dodamduck.R
+import coil.compose.rememberAsyncImagePainter
 import org.chosun.dodamduck.model.dto.ChatInfo
 import org.chosun.dodamduck.ui.theme.Orange
+import org.chosun.dodamduck.utils.Utils.getUserProfileUrl
 
 @Composable
 fun ChatUserItem(
@@ -58,10 +60,11 @@ fun ChatUserItem(
 @Composable
 fun ChatPartnerItem(
     modifier: Modifier = Modifier,
-    chatInfo: ChatInfo
+    chatInfo: ChatInfo,
+    otherUser: String = ""
 ) {
     Row(
-        modifier = modifier
+        modifier = modifier.padding(top = 10.dp)
     ) {
         Image(
             modifier = Modifier
@@ -70,12 +73,12 @@ fun ChatPartnerItem(
                 .size(60.dp, 60.dp)
                 .clip(RoundedCornerShape(25.dp)),
             contentScale = ContentScale.Crop,
-            painter = painterResource(id = R.drawable.img_user_profile),
+            painter = rememberAsyncImagePainter(otherUser.getUserProfileUrl()),
             contentDescription = "UserProfile"
         )
 
         Surface(
-            modifier = Modifier.align(CenterVertically),
+            modifier = Modifier.align(CenterVertically).wrapContentWidth().widthIn(max = 250.dp),
             color = Color(0xFFEDEDED),
             shape = RoundedCornerShape(40)
         ) {
@@ -88,7 +91,7 @@ fun ChatPartnerItem(
             modifier = Modifier
                 .align(Bottom)
                 .padding(start = 3.dp, bottom = 6.dp),
-            text = chatInfo.timestamp, color = Color.Gray, fontSize = 9.sp
+            text = chatInfo.timestamp.split(" ")[0], color = Color.Gray, fontSize = 9.sp
         )
         Spacer(Modifier.weight(1f))
     }
@@ -98,6 +101,7 @@ fun ChatLazyList(
     modifier: Modifier = Modifier,
     list: List<ChatInfo>,
     currentUser: String,
+    otherUser: String
 ) {
     val listState = rememberLazyListState()
 
@@ -116,7 +120,7 @@ fun ChatLazyList(
         ) {
             items(list.size) { index ->
                 if (list[index].senderID != currentUser)
-                    ChatPartnerItem(modifier = Modifier.padding(top = 7.dp), chatInfo = list[index])
+                    ChatPartnerItem(modifier = Modifier.padding(top = 7.dp), chatInfo = list[index], otherUser = otherUser )
                 else
                     ChatUserItem(modifier = Modifier.padding(top = 7.dp), list[index])
             }

--- a/dodamduck_aos/app/src/main/java/org/chosun/dodamduck/ui/navigation/DodamDuckNavigation.kt
+++ b/dodamduck_aos/app/src/main/java/org/chosun/dodamduck/ui/navigation/DodamDuckNavigation.kt
@@ -17,9 +17,11 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.navigation.NavHostController
+import androidx.navigation.NavType
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.compose.currentBackStackEntryAsState
+import androidx.navigation.navArgument
 import org.chosun.dodamduck.R
 import org.chosun.dodamduck.ui.ChatListScreen
 import org.chosun.dodamduck.ui.ChatScreen
@@ -39,23 +41,30 @@ sealed class BottomNavItem(
 ) {
     object Home : BottomNavItem(R.string.home, R.drawable.ic_home_48, R.string.home.toString())
 
-    object TradeWrite : BottomNavItem(R.string.trade_write, R.drawable.ic_home_48, R.string.trade_write.toString())
+    object TradeWrite :
+        BottomNavItem(R.string.trade_write, R.drawable.ic_home_48, R.string.trade_write.toString())
 
-    object Onboarding : BottomNavItem(R.string.onboarding, R.drawable.ic_home_48, R.string.onboarding.toString())
+    object Onboarding :
+        BottomNavItem(R.string.onboarding, R.drawable.ic_home_48, R.string.onboarding.toString())
 
-    object Register : BottomNavItem(R.string.register, R.drawable.ic_home_48, R.string.register.toString())
+    object Register :
+        BottomNavItem(R.string.register, R.drawable.ic_home_48, R.string.register.toString())
 
     object Login : BottomNavItem(R.string.login, R.drawable.ic_home_48, R.string.login.toString())
 
-    object Library : BottomNavItem(R.string.library, R.drawable.ic_toy_48, R.string.library.toString())
+    object Library :
+        BottomNavItem(R.string.library, R.drawable.ic_toy_48, R.string.library.toString())
 
     object Post : BottomNavItem(R.string.board, R.drawable.ic_board_48, R.string.board.toString())
 
-    object PostWrite : BottomNavItem(R.string.post_write, R.drawable.ic_board_48, R.string.post_write.toString())
-    
-    object PostDetail: BottomNavItem(R.string.post_detail, R.drawable.ic_board_48, R.string.post_detail.toString())
+    object PostWrite :
+        BottomNavItem(R.string.post_write, R.drawable.ic_board_48, R.string.post_write.toString())
 
-    object ChatList : BottomNavItem(R.string.chat_list, R.drawable.ic_chat_48, R.string.chat_list.toString())
+    object PostDetail :
+        BottomNavItem(R.string.post_detail, R.drawable.ic_board_48, R.string.post_detail.toString())
+
+    object ChatList :
+        BottomNavItem(R.string.chat_list, R.drawable.ic_chat_48, R.string.chat_list.toString())
 
     object Chat : BottomNavItem(R.string.chat, R.drawable.ic_chat_48, R.string.chat.toString())
 
@@ -64,7 +73,10 @@ sealed class BottomNavItem(
 
 @Composable
 fun daoDamDuckNavigationGraph(navController: NavHostController) {
-    NavHost(navController = navController, startDestination = BottomNavItem.Onboarding.screenRoute) {
+    NavHost(
+        navController = navController,
+        startDestination = BottomNavItem.Onboarding.screenRoute
+    ) {
         composable(BottomNavItem.Home.screenRoute) {
             TradeScreen(navController)
         }
@@ -86,8 +98,30 @@ fun daoDamDuckNavigationGraph(navController: NavHostController) {
         composable(BottomNavItem.ChatList.screenRoute) {
             ChatListScreen(navController)
         }
-        composable(BottomNavItem.Chat.screenRoute) {
-            ChatScreen(navController)
+        composable(
+            route = "${BottomNavItem.Chat.screenRoute}/{currentUser}/{otherUser}/{postImageUrl}/{postTitle}/{category}",
+            arguments = listOf(
+                navArgument("currentUser") { type = NavType.StringType },
+                navArgument("otherUser") { type = NavType.StringType },
+                navArgument("postImageUrl") { type = NavType.StringType },
+                navArgument("postTitle") { type = NavType.StringType },
+                navArgument("category") { type = NavType.StringType }
+            )
+        ) { backStackEntry ->
+            val currentUser = backStackEntry.arguments?.getString("currentUser")
+            val otherUser = backStackEntry.arguments?.getString("otherUser")
+            val postImageUrl = backStackEntry.arguments?.getString("postImageUrl")
+            val postTitle = backStackEntry.arguments?.getString("postTitle")
+            val category = backStackEntry.arguments?.getString("category")
+
+            ChatScreen(
+                navController,
+                currentUser = currentUser ?: "",
+                otherUser = otherUser ?: "",
+                postImageUrl = postImageUrl ?: "",
+                postTitle = postTitle ?: "",
+                category = category ?: ""
+            )
         }
         composable(BottomNavItem.Post.screenRoute) {
             PostScreen(navController)
@@ -117,13 +151,13 @@ fun DodamDuckBottomNavigation(navController: NavHostController) {
     val navBackStackEntry by navController.currentBackStackEntryAsState()
     val currentRoute = navBackStackEntry?.destination?.route
 
-    if(currentRoute != BottomNavItem.Onboarding.screenRoute
+    if (currentRoute != BottomNavItem.Onboarding.screenRoute
         && currentRoute != BottomNavItem.Register.screenRoute
         && currentRoute != BottomNavItem.Login.screenRoute
         && currentRoute != BottomNavItem.TradeWrite.screenRoute
         && currentRoute != BottomNavItem.PostWrite.screenRoute
         && currentRoute != BottomNavItem.PostDetail.screenRoute
-        ) {
+    ) {
         BottomNavigation(
             backgroundColor = Color.White,
             contentColor = Color(0xFF3F414E)

--- a/dodamduck_aos/app/src/main/java/org/chosun/dodamduck/utils/Utils.kt
+++ b/dodamduck_aos/app/src/main/java/org/chosun/dodamduck/utils/Utils.kt
@@ -47,4 +47,13 @@ object Utils {
         val filePart = MultipartBody.Part.createFormData("image", filename, requestBody!!)
         return filePart
     }
+
+    fun String.getUserProfileUrl(): String
+        = "http://sy2978.dothome.co.kr/userProfile/user_id_${this}.jpg"
+
+    fun String.ellipsis(maxLength: Int): String {
+        return if (this.length > maxLength) this.substring(0, maxLength) + "..."
+        else this
+    }
+
 }


### PR DESCRIPTION
✓ 관련 이슈 번호
close #110 

---

❄️ 구현 내용
- 채팅 시 상대방 이름 표시
- 채팅 목록 API 데이터 UI 반영
- 사용자 ID -> 사용자 프로필 URL 변환 유틸 함수 구현
- 채팅 목록 API 연동

📸 스크린샷 
 <table>
  <tr>
    <td><img width="300" src="https://github.com/DodamDuck/DodamDuck/assets/54762273/41735bc2-dcb6-420e-961c-7b2673265ef4"></td>
  </tr>
  <tr>
    <td align="center"><b>채팅 기록</b></td>
  </tr>
</table>


