### PR TITLE
[AOS] feat: 거래 / 나눔 상세보기 API 연동

### DIFF
--- a/dodamduck_aos/app/src/main/java/org/chosun/dodamduck/DodamDuckApp.kt
+++ b/dodamduck_aos/app/src/main/java/org/chosun/dodamduck/DodamDuckApp.kt
@@ -8,7 +8,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.navigation.compose.rememberNavController
 import org.chosun.dodamduck.ui.navigation.DodamDuckBottomNavigation
-import org.chosun.dodamduck.ui.navigation.daoDamDuckNavigationGraph
+import org.chosun.dodamduck.ui.navigation.DoDamDuckNavigationGraph
 import org.chosun.dodamduck.ui.theme.DodamDuckTheme
 
 @Composable
@@ -19,7 +19,7 @@ fun DodamDuckApp () {
             bottomBar = { DodamDuckBottomNavigation(navController = navController) }
         ) {
             Box(Modifier.padding(it)) {
-                daoDamDuckNavigationGraph(navController = navController)
+                DoDamDuckNavigationGraph(navController = navController)
             }
         }
     }

--- a/dodamduck_aos/app/src/main/java/org/chosun/dodamduck/model/dto/TradeDetailResponse.kt
+++ b/dodamduck_aos/app/src/main/java/org/chosun/dodamduck/model/dto/TradeDetailResponse.kt
@@ -14,7 +14,9 @@ data class TradeDetail(
     val verification_count: String,
     val image_url: String,
     val category: String,
-    val user_id: String
+    val user_id: String,
+    val created_at: String
+
 )
 
 data class TradeDetailComments(

--- a/dodamduck_aos/app/src/main/java/org/chosun/dodamduck/model/dto/TradeDetailResponse.kt
+++ b/dodamduck_aos/app/src/main/java/org/chosun/dodamduck/model/dto/TradeDetailResponse.kt
@@ -1,0 +1,27 @@
+package org.chosun.dodamduck.model.dto
+
+data class TradeDetailResponse(
+    val post: TradeDetail,
+    val comments: List<TradeDetailComments>
+)
+
+data class TradeDetail(
+    val title: String,
+    val content: String,
+    val views: String,
+    val userName: String,
+    val location: String,
+    val verification_count: String,
+    val image_url: String,
+    val category: String,
+    val user_id: String
+)
+
+data class TradeDetailComments(
+    val content: String,
+    val user_id: String,
+    val userName: String,
+    val verification_count: String,
+    val location: String,
+    val created_at: String
+)

--- a/dodamduck_aos/app/src/main/java/org/chosun/dodamduck/model/network/TradeApiService.kt
+++ b/dodamduck_aos/app/src/main/java/org/chosun/dodamduck/model/network/TradeApiService.kt
@@ -3,6 +3,9 @@ package org.chosun.dodamduck.model.network
 import okhttp3.MultipartBody
 import okhttp3.RequestBody
 import org.chosun.dodamduck.model.dto.Trade
+import org.chosun.dodamduck.model.dto.TradeDetailResponse
+import retrofit2.http.Field
+import retrofit2.http.FormUrlEncoded
 import retrofit2.http.GET
 import retrofit2.http.Multipart
 import retrofit2.http.POST
@@ -22,4 +25,11 @@ interface TradeApiService {
         @Part("location") location: RequestBody,
         @Part image: MultipartBody.Part
     ): DodamDuckResponse
+
+
+    @POST("PostDetail.php")
+    @FormUrlEncoded
+    suspend fun getTradeDetail(
+        @Field("post_id") postId: String
+    ): TradeDetailResponse
 }

--- a/dodamduck_aos/app/src/main/java/org/chosun/dodamduck/model/repository/TradeRepository.kt
+++ b/dodamduck_aos/app/src/main/java/org/chosun/dodamduck/model/repository/TradeRepository.kt
@@ -3,6 +3,7 @@ package org.chosun.dodamduck.model.repository
 import okhttp3.MultipartBody
 import okhttp3.RequestBody
 import org.chosun.dodamduck.model.dto.Trade
+import org.chosun.dodamduck.model.dto.TradeDetailResponse
 import org.chosun.dodamduck.model.network.TradeApiService
 import javax.inject.Inject
 
@@ -22,5 +23,11 @@ class TradeRepository @Inject constructor(
         image: MultipartBody.Part
     ) {
         service?.uploadTrade(userId, categoryId, title, content, location, image)
+    }
+
+    suspend fun fetchTradeDetail(
+        postId: String
+    ): TradeDetailResponse? {
+        return service?.getTradeDetail(postId)
     }
 }

--- a/dodamduck_aos/app/src/main/java/org/chosun/dodamduck/model/viewmodel/TradeViewModel.kt
+++ b/dodamduck_aos/app/src/main/java/org/chosun/dodamduck/model/viewmodel/TradeViewModel.kt
@@ -9,6 +9,7 @@ import kotlinx.coroutines.launch
 import okhttp3.MultipartBody
 import okhttp3.RequestBody
 import org.chosun.dodamduck.model.dto.Trade
+import org.chosun.dodamduck.model.dto.TradeDetailResponse
 import org.chosun.dodamduck.model.repository.TradeRepository
 import javax.inject.Inject
 
@@ -19,6 +20,9 @@ class TradeViewModel @Inject constructor(
 
     private val _tradeLists = MutableStateFlow<List<Trade>?>(null)
     val tradeLists: StateFlow<List<Trade>?> = _tradeLists
+
+    private val _tradeDetail = MutableStateFlow<TradeDetailResponse?>(null)
+    val tradeDetail: StateFlow<TradeDetailResponse?> = _tradeDetail
 
     fun getTradeLists() {
         viewModelScope.launch {
@@ -36,6 +40,12 @@ class TradeViewModel @Inject constructor(
     ) {
         viewModelScope.launch {
             repository.uploadTrade(userId, categoryId, title, content, location, image)
+        }
+    }
+
+    fun getTradeDetail(postId: String) {
+        viewModelScope.launch {
+            _tradeDetail.value = repository.fetchTradeDetail(postId)
         }
     }
 }

--- a/dodamduck_aos/app/src/main/java/org/chosun/dodamduck/ui/PostDetail.kt
+++ b/dodamduck_aos/app/src/main/java/org/chosun/dodamduck/ui/PostDetail.kt
@@ -88,7 +88,7 @@ fun PostDetailScreen(
                     modifier = Modifier.padding(top = 10.dp, start = 10.dp),
                     horizontalPadding = 25.dp,
                     verticalPadding = 8.dp,
-                    text = if(tradeDetail?.post?.category == "1") "교환" else "나눔영", fontSize = 15, fontWeight = FontWeight.SemiBold
+                    text = if(tradeDetail?.post?.category == "1") "교환" else "나눔", fontSize = 15, fontWeight = FontWeight.SemiBold
                 )
 
                 PostDetailUserInfo(

--- a/dodamduck_aos/app/src/main/java/org/chosun/dodamduck/ui/PostDetail.kt
+++ b/dodamduck_aos/app/src/main/java/org/chosun/dodamduck/ui/PostDetail.kt
@@ -19,6 +19,7 @@ import androidx.compose.material.Divider
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.KeyboardArrowLeft
 import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -96,7 +97,9 @@ fun PostDetailScreen(
                     userName = tradeDetail?.post?.userName ?: "도담덕 유저",
                     userProfile = tradeDetail?.post?.user_id?.getUserProfileUrl()
                         ?: "userProfileUrl",
-                    userInfo = stringResource(id = R.string.dummy_post_info_item)
+                    userInfo = "${tradeDetail?.post?.location?.split(" ")?.get(0)} ·" +
+                            " ${tradeDetail?.post?.verification_count}회 · " +
+                            "${tradeDetail?.post?.created_at?.formatDateDiff()}"
                 )
 
                 SpannableText(
@@ -168,10 +171,11 @@ fun PostDetailUserInfo(
             modifier = Modifier.padding(start = 10.dp)
         ) {
             DodamDuckText(text = userName, fontSize = 15, fontWeight = FontWeight.Bold)
-            DodamDuckText(
+            Text(
                 modifier = Modifier.padding(top = 2.dp),
                 text = userInfo,
-                fontSize = 12,
+                style = MaterialTheme.typography.titleMedium,
+                fontSize = 12.sp,
                 color = Color.Gray
             )
             Text(postContent, fontSize = 15.sp)

--- a/dodamduck_aos/app/src/main/java/org/chosun/dodamduck/ui/Trade.kt
+++ b/dodamduck_aos/app/src/main/java/org/chosun/dodamduck/ui/Trade.kt
@@ -59,7 +59,8 @@ fun TradeScreen(
             TradeHeader()
             ExchangeItemList(
                 modifier = Modifier.padding(top = 24.dp),
-                items = tradeLists ?: listOf()
+                items = tradeLists ?: listOf(),
+                navController = navController
             )
         }
 

--- a/dodamduck_aos/app/src/main/java/org/chosun/dodamduck/ui/component/InputText.kt
+++ b/dodamduck_aos/app/src/main/java/org/chosun/dodamduck/ui/component/InputText.kt
@@ -200,12 +200,13 @@ fun PreviewAuthInputTextList() {
 
 @Composable
 fun DodamDuckMessageInputField(
+    modifier:Modifier = Modifier,
     onSendButtonClick: () -> Unit = {},
     onTextFieldChange: (String) -> Unit = {},
     value: String = ""
 ) {
     Row(
-        modifier = Modifier
+        modifier = modifier
             .fillMaxWidth()
             .padding(horizontal = 10.dp),
         verticalAlignment = Alignment.CenterVertically

--- a/dodamduck_aos/app/src/main/java/org/chosun/dodamduck/ui/component/lazy_components/ExchangeItem.kt
+++ b/dodamduck_aos/app/src/main/java/org/chosun/dodamduck/ui/component/lazy_components/ExchangeItem.kt
@@ -1,6 +1,7 @@
 package org.chosun.dodamduck.ui.component.lazy_components
 
 import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -23,38 +24,44 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import androidx.navigation.NavController
+import androidx.navigation.compose.rememberNavController
 import coil.compose.AsyncImage
 import org.chosun.dodamduck.model.dto.Trade
 import org.chosun.dodamduck.ui.component.CommentIcon
 import org.chosun.dodamduck.ui.component.DodamDuckTextH3
+import org.chosun.dodamduck.ui.navigation.BottomNavItem
 import org.chosun.dodamduck.utils.Utils.formatDateDiff
 
 @Composable
 @Preview(showBackground = true)
 fun PreviewExchangeItemList() {
     Box(modifier = Modifier.fillMaxWidth()) {
-        ExchangeItemList()
+        ExchangeItemList(navController = rememberNavController())
     }
 }
 
 @Composable
 fun ExchangeItemList(
     modifier: Modifier = Modifier,
-    items: List<Trade> = listOf()
+    items: List<Trade> = listOf(),
+    navController: NavController
 ) {
     LazyColumn(
         modifier = modifier.padding(horizontal = 10.dp)
     ) {
         items(items.size) {
-            ExchangeItemItem(items[it])
+            ExchangeItem(items[it], navController)
             Divider(modifier = Modifier.padding(top = 6.dp, bottom = 16.dp))
         }
     }
 }
 
 @Composable
-fun ExchangeItemItem(item: Trade) {
-    Row {
+fun ExchangeItem(item: Trade, navController: NavController) {
+    Row(
+        modifier = Modifier.clickable { navController.navigate("${BottomNavItem.PostDetail.screenRoute}/${item.post_id}") }
+    ) {
         AsyncImage(
             modifier = Modifier
                 .border(1.dp, Color.Gray, RoundedCornerShape(10.dp))

--- a/dodamduck_aos/app/src/main/java/org/chosun/dodamduck/ui/navigation/DodamDuckNavigation.kt
+++ b/dodamduck_aos/app/src/main/java/org/chosun/dodamduck/ui/navigation/DodamDuckNavigation.kt
@@ -72,7 +72,7 @@ sealed class BottomNavItem(
 }
 
 @Composable
-fun daoDamDuckNavigationGraph(navController: NavHostController) {
+fun DoDamDuckNavigationGraph(navController: NavHostController) {
     NavHost(
         navController = navController,
         startDestination = BottomNavItem.Onboarding.screenRoute
@@ -126,8 +126,14 @@ fun daoDamDuckNavigationGraph(navController: NavHostController) {
         composable(BottomNavItem.Post.screenRoute) {
             PostScreen(navController)
         }
-        composable(BottomNavItem.PostDetail.screenRoute) {
-            PostDetailScreen(navController)
+        composable(
+            route = "${BottomNavItem.PostDetail.screenRoute}/{postId}",
+            arguments = listOf(
+                navArgument("postId") { type = NavType.StringType }
+            )
+        ) { backStackEntry ->
+            val postId = backStackEntry.arguments?.getString("postId")
+            PostDetailScreen(navController, postId = postId ?: "")
         }
         composable(BottomNavItem.PostWrite.screenRoute) {
             PostWriteScreen(navController)


### PR DESCRIPTION
✓ 관련 이슈 번호
close #114 

---

❄️ 구현 내용
 - 거래 / 나눔 상세보기 API 연동
 - 게시물 데이터 UI에 반영
 - 댓글 데이터 UI에 반영
 - 화면 상세보기에 스크롤 적용

📸 스크린샷 

[Screen_recording_20231122_033741.webm](https://github.com/DodamDuck/DodamDuck/assets/54762273/5b13dd4c-7f55-4ef3-8f90-8efa554213b9)



