### PR TITLE
[AOS] feat: 회원가입 API 연동

### DIFF
--- a/dodamduck_aos/app/src/main/java/org/chosun/dodamduck/model/network/AuthApiService.kt
+++ b/dodamduck_aos/app/src/main/java/org/chosun/dodamduck/model/network/AuthApiService.kt
@@ -14,4 +14,12 @@ interface AuthApiService {
         @Field("userPassword") password: String
     ): LoginDTO
 
+    @FormUrlEncoded
+    @POST("Register.php")
+    suspend fun requestRegister(
+        @Field("userID") userID: String,
+        @Field("userPassword") password: String,
+        @Field("location") location: String
+    ): DodamDuckResponse
+
 }

--- a/dodamduck_aos/app/src/main/java/org/chosun/dodamduck/model/repository/AuthRepository.kt
+++ b/dodamduck_aos/app/src/main/java/org/chosun/dodamduck/model/repository/AuthRepository.kt
@@ -2,6 +2,7 @@ package org.chosun.dodamduck.model.repository
 
 import org.chosun.dodamduck.model.dto.LoginDTO
 import org.chosun.dodamduck.model.network.AuthApiService
+import org.chosun.dodamduck.model.network.DodamDuckResponse
 import javax.inject.Inject
 
 class AuthRepository @Inject constructor(
@@ -12,5 +13,13 @@ class AuthRepository @Inject constructor(
         userPassword: String
     ): LoginDTO? {
         return service?.requestLogin(userID, userPassword)
+    }
+
+    suspend fun requestRegister(
+        userID: String,
+        userPassword: String,
+        location: String
+    ): DodamDuckResponse? {
+        return service?.requestRegister(userID, userPassword, location)
     }
 }

--- a/dodamduck_aos/app/src/main/java/org/chosun/dodamduck/model/viewmodel/AuthViewModel.kt
+++ b/dodamduck_aos/app/src/main/java/org/chosun/dodamduck/model/viewmodel/AuthViewModel.kt
@@ -17,6 +17,9 @@ class AuthViewModel @Inject constructor(
 
     private val _isLoginState = MutableStateFlow<Boolean>(false)
     val isLoginState: StateFlow<Boolean> = _isLoginState
+
+    private val _isRegisterState = MutableStateFlow<String>("true")
+    val isRegisterState: StateFlow<String> = _isRegisterState
     suspend fun loginRequest(
         userID: String,
         userPassword: String
@@ -25,6 +28,17 @@ class AuthViewModel @Inject constructor(
             val result = repository.requestLogin(userID, userPassword)
             _isLoginState.value = result?.login_success ?: false
             DodamDuckData.userInfo = result
+        }
+    }
+
+    suspend fun registerRequest(
+        userID: String,
+        userPassword: String,
+        location: String =""
+    ) {
+        viewModelScope.launch {
+            val result = repository.requestRegister(userID, userPassword, location)
+            _isRegisterState.value = result?.error ?: "true"
         }
     }
 }

--- a/dodamduck_aos/app/src/main/java/org/chosun/dodamduck/ui/Register.kt
+++ b/dodamduck_aos/app/src/main/java/org/chosun/dodamduck/ui/Register.kt
@@ -1,5 +1,6 @@
 package org.chosun.dodamduck.ui
 
+import android.widget.Toast
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -7,13 +8,22 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.height
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.navigation.NavHostController
 import androidx.navigation.compose.rememberNavController
 import org.chosun.dodamduck.R
+import org.chosun.dodamduck.model.viewmodel.AuthViewModel
 import org.chosun.dodamduck.ui.component.AuthBody
 import org.chosun.dodamduck.ui.component.AuthTopSurface
 import org.chosun.dodamduck.ui.navigation.BottomNavItem
@@ -21,7 +31,35 @@ import org.chosun.dodamduck.ui.theme.DodamDuckTheme
 import org.chosun.dodamduck.ui.theme.Primary
 
 @Composable
-fun RegisterScreen(navController: NavHostController) {
+fun RegisterScreen(
+    navController: NavHostController,
+    authViewModel: AuthViewModel = hiltViewModel()
+) {
+    val isRegisterError by authViewModel.isRegisterState.collectAsState(initial = "true")
+
+    var userID by remember { mutableStateOf("") }
+    var password by remember { mutableStateOf("") }
+    var confirmPass by remember { mutableStateOf("") }
+    var registerLoading by remember { mutableStateOf(false) }
+
+    val context = LocalContext.current
+    val checkPasswordMessage = stringResource(R.string.passwords_do_not_match_each_other)
+
+
+    if (registerLoading) {
+        LaunchedEffect(key1 = Unit) {
+            authViewModel.registerRequest(userID, password)
+        }
+    }
+
+    LaunchedEffect(key1 = isRegisterError) {
+        if (isRegisterError == "false") {
+            navController.navigate(BottomNavItem.Login.screenRoute)
+        } else if (registerLoading) {
+            registerLoading = false
+        }
+    }
+
     Box(
         modifier = Modifier
             .fillMaxSize()
@@ -43,7 +81,18 @@ fun RegisterScreen(navController: NavHostController) {
                 checkBoxText = stringResource(id = R.string.confirmed_the_terms_and_conditions),
                 buttonText = stringResource(id = R.string.register),
                 alreadyText = stringResource(id = R.string.already_account),
-                bottomTextAction = {navController.navigate(BottomNavItem.Login.screenRoute)}
+                bottomTextAction = { navController.navigate(BottomNavItem.Login.screenRoute) },
+                buttonAction = {
+                    if(password != confirmPass)
+                        Toast.makeText(context, checkPasswordMessage, Toast.LENGTH_LONG ).show()
+                    else registerLoading = true
+                               },
+                onUserIDChange = { newUserID -> userID = newUserID },
+                onPasswordChange = { newPassword -> password = newPassword },
+                onConfirmChange = { newConfirm -> confirmPass = newConfirm },
+                emailText = userID,
+                passwordText = password,
+                confirmPasswordText = confirmPass
             )
         }
     }

--- a/dodamduck_aos/app/src/main/java/org/chosun/dodamduck/ui/component/AuthBody.kt
+++ b/dodamduck_aos/app/src/main/java/org/chosun/dodamduck/ui/component/AuthBody.kt
@@ -39,8 +39,10 @@ fun AuthBody(
     alreadyText: String,
     onUserIDChange: (String) -> Unit = {},
     onPasswordChange: (String) -> Unit = {},
+    onConfirmChange: (String) -> Unit = {},
     emailText: String = "",
-    passwordText: String = ""
+    passwordText: String = "",
+    confirmPasswordText: String = ""
 ) {
     Box(
         modifier = Modifier
@@ -60,8 +62,10 @@ fun AuthBody(
                 labelList = labelList,
                 onUserIDChange = onUserIDChange,
                 onPasswordChange = onPasswordChange,
+                onConfirmChange = onConfirmChange,
                 emailText = emailText,
-                passwordText = passwordText
+                passwordText = passwordText,
+                confirmPasswordText = confirmPasswordText
             )
 
             DodamDuckCheckBox(

--- a/dodamduck_aos/app/src/main/java/org/chosun/dodamduck/ui/component/InputText.kt
+++ b/dodamduck_aos/app/src/main/java/org/chosun/dodamduck/ui/component/InputText.kt
@@ -186,8 +186,10 @@ fun AuthInputTextList(
     labelList: List<String>,
     onUserIDChange: (String) -> Unit = {},
     onPasswordChange: (String) -> Unit = {},
+    onConfirmChange: (String) -> Unit = {},
     emailText: String = "",
-    passwordText: String = ""
+    passwordText: String = "",
+    confirmPasswordText: String = ""
 ) {
     var passwordVisible by remember { mutableStateOf(false) }
     var passwordConfirmVisible by remember { mutableStateOf(false) }
@@ -203,8 +205,8 @@ fun AuthInputTextList(
                         else passwordConfirmVisible = !passwordConfirmVisible
                     },
                     iconState = if (index == 1) passwordVisible else passwordConfirmVisible,
-                    onValueChange = onPasswordChange,
-                    text = passwordText
+                    onValueChange = if(index == 1) onPasswordChange else onConfirmChange,
+                    text = if (index == 1) passwordText else confirmPasswordText,
                 )
             } else {
                 DodamDuckTextField(

--- a/dodamduck_aos/app/src/main/res/values/strings.xml
+++ b/dodamduck_aos/app/src/main/res/values/strings.xml
@@ -67,4 +67,5 @@
     <string name="post_detail">게시물 상세</string>
     <string name="chat_list">채팅 기록</string>
     <string name="please_check_your_login_information">로그인 정보를 다시 확인해 주세요.</string>
+    <string name="passwords_do_not_match_each_other">비밀번호가 서로 일치하지 않습니다.</string>
 </resources>


### PR DESCRIPTION
✓ 관련 이슈 번호
close #119 

---

❄️ 구현 내용
 - 회원가입 API 연동
 - 회원가입 API 연동 후 UI 상태 반영
 
📸 스크린샷 
 <table>
  <tr>
    <td><img width="300" src="https://github.com/DodamDuck/DodamDuck/assets/54762273/cc469e83-7ca6-46ce-adb6-025bd2aca4ed"></td>
  <td><img width="300" src="https://github.com/DodamDuck/DodamDuck/assets/54762273/67f776f6-5f6d-497e-a190-8c8ec4c19271"></td>
  </tr>
  <tr>
    <td align="center"><b>회원가입 성공시 로그인 화면 전환</b></td>
    <td align="center"><b>비밀번호가 일치하지 않을시</b></td>
  </tr>
</table>
