### PR TITLE
[AOS] feat: 게시글 조회 API 연동 

### DIFF
--- a/dodamduck_aos/app/src/main/java/org/chosun/dodamduck/model/di/NetworkModule.kt
+++ b/dodamduck_aos/app/src/main/java/org/chosun/dodamduck/model/di/NetworkModule.kt
@@ -6,6 +6,7 @@ import dagger.hilt.InstallIn
 import dagger.hilt.components.SingletonComponent
 import org.chosun.dodamduck.model.network.AuthApiService
 import org.chosun.dodamduck.model.network.ChatApiService
+import org.chosun.dodamduck.model.network.PostApiService
 import org.chosun.dodamduck.model.network.RetrofitClient
 import org.chosun.dodamduck.model.network.ToyLibraryApiService
 import org.chosun.dodamduck.model.network.TradeApiService
@@ -49,5 +50,10 @@ object NetworkModule {
     @Provides
     fun provideAuthApiService(@Named("DodamDuckRetrofit") retrofit: Retrofit): AuthApiService {
         return retrofit.create(AuthApiService::class.java)
+    }
+
+    @Provides
+    fun providePostApiService(@Named("DodamDuckRetrofit") retrofit: Retrofit): PostApiService {
+        return retrofit.create(PostApiService::class.java)
     }
 }

--- a/dodamduck_aos/app/src/main/java/org/chosun/dodamduck/model/dto/PostDTO.kt
+++ b/dodamduck_aos/app/src/main/java/org/chosun/dodamduck/model/dto/PostDTO.kt
@@ -1,0 +1,27 @@
+package org.chosun.dodamduck.model.dto
+
+import com.google.gson.annotations.SerializedName
+
+data class PostDTO(
+    @SerializedName("ShareID") val shareID: String,
+    @SerializedName("UserID") val userID: String,
+    @SerializedName("CategoryID") val categoryID: String,
+    @SerializedName("Title") val title: String,
+    @SerializedName("Content") val content: String,
+    @SerializedName("ImageURL") val imageURL: String,
+    @SerializedName("CreatedAt") val createdAt: String,
+    @SerializedName("UpdatedAt") val updatedAt: String,
+    @SerializedName("Location") val location: String,
+    @SerializedName("Views") val views: String,
+    @SerializedName("CommentCount") val commentCount: String,
+    @SerializedName("CategoryName") val categoryName: String
+)
+
+data class PostCommentDTO(
+    @SerializedName("CommentID") val commentID: String,
+    @SerializedName("ShareID") val shareID: String,
+    @SerializedName("UserID") val userID: String,
+    @SerializedName("Comment") val comment: String,
+    @SerializedName("CreatedAt") val createAt: String,
+    @SerializedName("UpdatedAt") val updateAt: String
+)

--- a/dodamduck_aos/app/src/main/java/org/chosun/dodamduck/model/network/PostApiService.kt
+++ b/dodamduck_aos/app/src/main/java/org/chosun/dodamduck/model/network/PostApiService.kt
@@ -1,0 +1,10 @@
+package org.chosun.dodamduck.model.network
+
+import org.chosun.dodamduck.model.dto.PostDTO
+import retrofit2.http.GET
+
+interface PostApiService {
+
+    @GET("ContentShare.php")
+    suspend fun getPostList(): List<PostDTO>?
+}

--- a/dodamduck_aos/app/src/main/java/org/chosun/dodamduck/model/repository/PostRepository.kt
+++ b/dodamduck_aos/app/src/main/java/org/chosun/dodamduck/model/repository/PostRepository.kt
@@ -1,0 +1,13 @@
+package org.chosun.dodamduck.model.repository
+
+import org.chosun.dodamduck.model.dto.PostDTO
+import org.chosun.dodamduck.model.network.PostApiService
+import javax.inject.Inject
+
+class PostRepository @Inject constructor(
+    private val service: PostApiService?
+) {
+    suspend fun fetchPostList(): List<PostDTO> {
+        return service?.getPostList() ?: listOf()
+    }
+}

--- a/dodamduck_aos/app/src/main/java/org/chosun/dodamduck/model/viewmodel/PostViewModel.kt
+++ b/dodamduck_aos/app/src/main/java/org/chosun/dodamduck/model/viewmodel/PostViewModel.kt
@@ -1,0 +1,26 @@
+package org.chosun.dodamduck.model.viewmodel
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.launch
+import org.chosun.dodamduck.model.dto.PostDTO
+import org.chosun.dodamduck.model.repository.PostRepository
+import javax.inject.Inject
+
+@HiltViewModel
+class PostViewModel @Inject constructor(
+    private val repository: PostRepository
+) : ViewModel() {
+
+    private val _postLists = MutableStateFlow<List<PostDTO>?>(null)
+    val postLists: StateFlow<List<PostDTO>?> = _postLists
+
+    fun getPostLists() {
+        viewModelScope.launch {
+            _postLists.value = repository.fetchPostList()
+        }
+    }
+}

--- a/dodamduck_aos/app/src/main/java/org/chosun/dodamduck/ui/Post.kt
+++ b/dodamduck_aos/app/src/main/java/org/chosun/dodamduck/ui/Post.kt
@@ -21,6 +21,8 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -31,9 +33,11 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.navigation.NavHostController
 import androidx.navigation.compose.rememberNavController
 import org.chosun.dodamduck.R
+import org.chosun.dodamduck.model.viewmodel.PostViewModel
 import org.chosun.dodamduck.ui.component.DodamDuckTextH2
 import org.chosun.dodamduck.ui.component.lazy_components.PostItem
 import org.chosun.dodamduck.ui.component.lazy_components.TagLazyRow
@@ -42,9 +46,19 @@ import org.chosun.dodamduck.ui.theme.Brown
 import org.chosun.dodamduck.ui.theme.DodamDuckTheme
 
 @Composable
-fun PostScreen(navController: NavHostController) {
+fun PostScreen(
+    navController: NavHostController,
+    postViewModel: PostViewModel = hiltViewModel()
+) {
     val tags = listOf("주제", "인기글", "지식공유", "지식유형", "인기글", "인기글", "인기글")
     var selectedTag by remember { mutableStateOf(tags.first()) }
+
+    val postLists by postViewModel.postLists.collectAsState(initial = null)
+
+    LaunchedEffect(Unit) {
+        postViewModel.getPostLists()
+    }
+
 
     Box(
         modifier = Modifier
@@ -63,11 +77,13 @@ fun PostScreen(navController: NavHostController) {
             )
             Divider(modifier = Modifier.padding(top = 10.dp))
 
-            LazyColumn() {
-                items(10) {
+            val posts = postLists ?: listOf()
+            LazyColumn {
+                items(posts.size) {index ->
                     PostItem(modifier = Modifier
                         .padding(start = 8.dp, end = 8.dp, top = 8.dp)
-                        .clickable { navController.navigate(BottomNavItem.PostDetail.screenRoute) }
+                        .clickable { navController.navigate(BottomNavItem.PostDetail.screenRoute) },
+                        item = posts[index]
                     )
                     Divider()
                 }

--- a/dodamduck_aos/app/src/main/java/org/chosun/dodamduck/ui/component/lazy_components/PostLazy.kt
+++ b/dodamduck_aos/app/src/main/java/org/chosun/dodamduck/ui/component/lazy_components/PostLazy.kt
@@ -26,32 +26,40 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import coil.compose.rememberAsyncImagePainter
 import org.chosun.dodamduck.R
+import org.chosun.dodamduck.model.dto.PostDTO
 import org.chosun.dodamduck.ui.component.CommentIcon
 import org.chosun.dodamduck.ui.component.DodamDuckText
 import org.chosun.dodamduck.ui.component.DodamDuckTextH3
 import org.chosun.dodamduck.ui.theme.Brown
+import org.chosun.dodamduck.utils.Utils.ellipsis
+import org.chosun.dodamduck.utils.Utils.formatDateDiff
 
 @Composable
-fun PostItem(modifier: Modifier = Modifier) {
+fun PostItem(
+    modifier: Modifier = Modifier,
+    item: PostDTO
+) {
     Row(
         modifier = modifier
             .fillMaxWidth()
             .wrapContentHeight()
     ) {
-        Column(modifier = Modifier.weight(1f)) {
-            PostType()
-            DodamDuckTextH3(text = "뽀로로 놀이 기구 어떤가요?")
+        Column(modifier = Modifier.weight(6f)) {
+            PostType(text = item.categoryName)
+            DodamDuckTextH3(text = item.title)
             DodamDuckText(
                 modifier = Modifier.padding(top = 4.dp),
-                text = "뽀로로 놀이 기구를 이벤트로 받았는데 ...",
+                text = item.content.ellipsis(40),
                 fontSize = 9,
                 color = Color.Gray
             )
-            DodamDuckText(
+            Text(
                 modifier = Modifier.padding(top = 2.dp),
-                text = stringResource(id = R.string.dummy_post_info_item),
-                fontSize = 9,
+                text = "${item.location} · ${item.createdAt.formatDateDiff()} · ${item.views}회",
+                fontSize = 9.sp,
                 color = Color.Gray
             )
         }
@@ -61,17 +69,18 @@ fun PostItem(modifier: Modifier = Modifier) {
                 modifier = Modifier
                     .border(1.dp, Color.Gray, RoundedCornerShape(10.dp))
                     .align(Alignment.End)
+                    .clip(RoundedCornerShape(10.dp))
                     .size(55.dp, 55.dp),
                 contentScale = ContentScale.Crop,
-                painter = painterResource(id = R.drawable.ic_duck),
+                painter = rememberAsyncImagePainter(item.imageURL),
                 contentDescription = "Exchange Item"
             )
 
             CommentIcon(
-                    modifier = Modifier
+                modifier = Modifier
                     .align(Alignment.End)
                     .padding(top = 2.dp),
-                text = "3"
+                text = item.commentCount
             )
         }
     }
@@ -107,7 +116,15 @@ fun PostItemPreview() {
     Box(Modifier.fillMaxSize()) {
         LazyColumn() {
             items(5) {
-                PostItem()
+                PostItem(
+                    item = PostDTO(
+                        "1", "user1",
+                        "1", "뽀로로 놀이기구 어떤가요?",
+                        "뽀로로 놀이 기구를 이벤트로 받았는데 ...",
+                        "", "2023-11-16 22:59:38","","빛가람동",
+                        "43", "2", "교환"
+                    )
+                )
             }
         }
     }


### PR DESCRIPTION
✓ 관련 이슈 번호
close #119 

---

❄️ 구현 내용
 - 회원가입 API 연동
 - 회원가입 API 연동 후 UI 상태 반영
 
📸 스크린샷 
 <table>
  <tr>
    <td><img width="300" src="https://github.com/DodamDuck/DodamDuck/assets/54762273/72e0b5c7-7b92-4fa9-aaf2-d48e88238fb4"></td>
  </tr>
  <tr>
    <td align="center"><b>게시글 화면</b></td>
  </tr>
</table>

