### PR TITLE
[AOS] feat: 게시글 방문시 조회수 증가시키는 API 연동

### DIFF
--- a/dodamduck_aos/app/src/main/java/org/chosun/dodamduck/model/network/PostApiService.kt
+++ b/dodamduck_aos/app/src/main/java/org/chosun/dodamduck/model/network/PostApiService.kt
@@ -25,4 +25,11 @@ interface PostApiService {
         @Field("user_id") userId: String,
         @Field("comment") content: String
     ): DodamDuckResponse
+
+    @POST("content_share_view_up.php")
+    @FormUrlEncoded
+    suspend fun uploadViews(
+        @Field("share_id") shareId: String
+    ): DodamDuckResponse
+
 }

--- a/dodamduck_aos/app/src/main/java/org/chosun/dodamduck/model/network/TradeApiService.kt
+++ b/dodamduck_aos/app/src/main/java/org/chosun/dodamduck/model/network/TradeApiService.kt
@@ -40,4 +40,11 @@ interface TradeApiService {
         @Field("user_id") userId: String,
         @Field("content") content: String
     ): DodamDuckResponse
+
+    @POST("upload_post_view_up.php")
+    @FormUrlEncoded
+    suspend fun uploadViews(
+        @Field("post_id") postId: String
+    ): DodamDuckResponse
+
 }

--- a/dodamduck_aos/app/src/main/java/org/chosun/dodamduck/model/repository/BasePostRepository.kt
+++ b/dodamduck_aos/app/src/main/java/org/chosun/dodamduck/model/repository/BasePostRepository.kt
@@ -13,4 +13,8 @@ interface BasePostRepository<ALL> {
         userID: String,
         comment: String
     ): DodamDuckResponse?
+
+    suspend fun uploadViewCount(
+        postID: String
+    ): DodamDuckResponse?
 }

--- a/dodamduck_aos/app/src/main/java/org/chosun/dodamduck/model/repository/PostRepository.kt
+++ b/dodamduck_aos/app/src/main/java/org/chosun/dodamduck/model/repository/PostRepository.kt
@@ -29,5 +29,9 @@ class PostRepository @Inject constructor(
         return service?.uploadComment(postID, userID, comment)
     }
 
+    override suspend fun uploadViewCount(postID: String): DodamDuckResponse? {
+        return service?.uploadViews(postID)
+    }
+
 
 }

--- a/dodamduck_aos/app/src/main/java/org/chosun/dodamduck/model/repository/TradeRepository.kt
+++ b/dodamduck_aos/app/src/main/java/org/chosun/dodamduck/model/repository/TradeRepository.kt
@@ -39,4 +39,8 @@ class TradeRepository @Inject constructor(
     ): DodamDuckResponse? {
         return service?.uploadComment(postID, userID, comment)
     }
+
+    override suspend fun uploadViewCount(postID: String): DodamDuckResponse? {
+        return service?.uploadViews(postID)
+    }
 }

--- a/dodamduck_aos/app/src/main/java/org/chosun/dodamduck/model/viewmodel/BasePostViewModel.kt
+++ b/dodamduck_aos/app/src/main/java/org/chosun/dodamduck/model/viewmodel/BasePostViewModel.kt
@@ -47,4 +47,10 @@ abstract class BasePostViewModel<ALL>(
             }
         }
     }
+
+    fun uploadViewCount(postID: String) {
+        viewModelScope.launch {
+            repository.uploadViewCount(postID)
+        }
+    }
 }

--- a/dodamduck_aos/app/src/main/java/org/chosun/dodamduck/ui/Post.kt
+++ b/dodamduck_aos/app/src/main/java/org/chosun/dodamduck/ui/Post.kt
@@ -81,7 +81,10 @@ fun PostScreen(
                 items(posts.size) {index ->
                     PostItem(modifier = Modifier
                         .padding(start = 8.dp, end = 8.dp, top = 8.dp)
-                        .clickable { navController.navigate("${BottomNavItem.PostDetail.screenRoute}/${posts[index].shareID}/post") },
+                        .clickable {
+                            postViewModel.uploadViewCount(posts[index].shareID)
+                            navController.navigate("${BottomNavItem.PostDetail.screenRoute}/${posts[index].shareID}/post")
+                                   },
                         item = posts[index]
                     )
                     Divider()

--- a/dodamduck_aos/app/src/main/java/org/chosun/dodamduck/ui/PostDetail.kt
+++ b/dodamduck_aos/app/src/main/java/org/chosun/dodamduck/ui/PostDetail.kt
@@ -144,7 +144,7 @@ fun PostDetailScreen(
 
                 Text(
                     modifier = Modifier.padding(top = 10.dp, start = 10.dp),
-                    text = "조회 ${postDetail?.post?.verification_count}",
+                    text = "조회 ${postDetail?.post?.views}",
                     color = Color.Gray
                 )
 

--- a/dodamduck_aos/app/src/main/java/org/chosun/dodamduck/ui/component/lazy_components/ExchangeItem.kt
+++ b/dodamduck_aos/app/src/main/java/org/chosun/dodamduck/ui/component/lazy_components/ExchangeItem.kt
@@ -24,10 +24,12 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.navigation.NavController
 import androidx.navigation.compose.rememberNavController
 import coil.compose.AsyncImage
 import org.chosun.dodamduck.model.dto.Trade
+import org.chosun.dodamduck.model.viewmodel.TradeViewModel
 import org.chosun.dodamduck.ui.component.CommentIcon
 import org.chosun.dodamduck.ui.component.DodamDuckTextH3
 import org.chosun.dodamduck.ui.navigation.BottomNavItem
@@ -45,22 +47,26 @@ fun PreviewExchangeItemList() {
 fun ExchangeItemList(
     modifier: Modifier = Modifier,
     items: List<Trade> = listOf(),
-    navController: NavController
+    navController: NavController,
+    tradeViewModel: TradeViewModel = hiltViewModel()
 ) {
     LazyColumn(
         modifier = modifier.padding(horizontal = 10.dp)
     ) {
         items(items.size) {
-            ExchangeItem(items[it], navController)
+            ExchangeItem(items[it], navController, tradeViewModel)
             Divider(modifier = Modifier.padding(top = 6.dp, bottom = 16.dp))
         }
     }
 }
 
 @Composable
-fun ExchangeItem(item: Trade, navController: NavController) {
+fun ExchangeItem(item: Trade, navController: NavController, tradeViewModel: TradeViewModel) {
     Row(
-        modifier = Modifier.clickable { navController.navigate("${BottomNavItem.PostDetail.screenRoute}/${item.post_id}/trade") }
+        modifier = Modifier.clickable {
+            tradeViewModel.uploadViewCount(item.post_id)
+            navController.navigate("${BottomNavItem.PostDetail.screenRoute}/${item.post_id}/trade")
+        }
     ) {
         AsyncImage(
             modifier = Modifier
@@ -68,7 +74,7 @@ fun ExchangeItem(item: Trade, navController: NavController) {
                 .size(80.dp)
                 .clip(RoundedCornerShape(10.dp)),
             contentScale = ContentScale.Crop,
-            model = item.image_url ,
+            model = item.image_url,
             contentDescription = "Image"
         )
 

--- a/dodamduck_aos/app/src/main/java/org/chosun/dodamduck/ui/component/lazy_components/ExchangeItem.kt
+++ b/dodamduck_aos/app/src/main/java/org/chosun/dodamduck/ui/component/lazy_components/ExchangeItem.kt
@@ -85,7 +85,7 @@ fun ExchangeItem(item: Trade, navController: NavController, tradeViewModel: Trad
             DodamDuckTextH3(text = item.title)
             Text(
                 text = item.location + " \u00B7 " + item.created_at.formatDateDiff() + " \u00B7 조회 " + item.views,
-                fontSize = 9.sp,
+                fontSize = 122.sp,
                 color = Color.Gray
             )
             DodamDuckTextH3(

--- a/dodamduck_aos/app/src/main/java/org/chosun/dodamduck/ui/component/lazy_components/ExchangeItem.kt
+++ b/dodamduck_aos/app/src/main/java/org/chosun/dodamduck/ui/component/lazy_components/ExchangeItem.kt
@@ -85,7 +85,7 @@ fun ExchangeItem(item: Trade, navController: NavController, tradeViewModel: Trad
             DodamDuckTextH3(text = item.title)
             Text(
                 text = item.location + " \u00B7 " + item.created_at.formatDateDiff() + " \u00B7 조회 " + item.views,
-                fontSize = 122.sp,
+                fontSize = 12.sp,
                 color = Color.Gray
             )
             DodamDuckTextH3(

--- a/dodamduck_aos/app/src/main/java/org/chosun/dodamduck/ui/component/lazy_components/PostLazy.kt
+++ b/dodamduck_aos/app/src/main/java/org/chosun/dodamduck/ui/component/lazy_components/PostLazy.kt
@@ -50,13 +50,13 @@ fun PostItem(
             DodamDuckText(
                 modifier = Modifier.padding(top = 4.dp),
                 text = item.content.ellipsis(40),
-                fontSize = 9,
+                fontSize = 12,
                 color = Color.Gray
             )
             Text(
                 modifier = Modifier.padding(top = 2.dp),
                 text = "${item.location} · ${item.createdAt.formatDateDiff()} · ${item.views}회",
-                fontSize = 9.sp,
+                fontSize = 12.sp,
                 color = Color.Gray
             )
         }


### PR DESCRIPTION
✓ 관련 이슈 번호
close #133 

---

❄️ 구현 내용
- 게시글 조회수 증가 API 연동 

---

📸 스크린샷 
 <table>
  <tr>
    <td><img width="300" src="https://github.com/DodamDuck/DodamDuck/assets/54762273/7a19061e-00fd-4492-97b7-b84016e29837)"></td>
    <td><img width="300" src="https://github.com/DodamDuck/DodamDuck/assets/54762273/7efac81c-28be-41d4-abf3-4ffbecf96ebb)">
</td>
  </tr>
  <tr>
    <td align="center"><b>거래/나눔 화면</b></td>
    <td align="center"><b>게시글 화면</b></td>
  </tr>
</table>

