### PR TITLE
[AOS] design: 장난감 도서관 사진 적용 

### DIFF
--- a/dodamduck_aos/app/src/main/java/org/chosun/dodamduck/ui/component/SearchBar.kt
+++ b/dodamduck_aos/app/src/main/java/org/chosun/dodamduck/ui/component/SearchBar.kt
@@ -5,8 +5,10 @@ import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.RoundedCornerShape
@@ -49,7 +51,10 @@ fun DodamDuckSearchBar(modifier: Modifier = Modifier) {
         Row(
             verticalAlignment = Alignment.CenterVertically,
             horizontalArrangement = Arrangement.Start,
-            modifier = Modifier.padding(start = 16.dp, end = 16.dp)
+            modifier = Modifier
+                .background(color = White9,
+                        shape = RoundedCornerShape(32.dp)
+                ).fillMaxSize()
         ) {
             DodamDuckText(
                 modifier = Modifier.weight(1f),
@@ -64,7 +69,7 @@ fun DodamDuckSearchBar(modifier: Modifier = Modifier) {
                 imageVector = Icons.Default.Search,
                 contentDescription = "Search Icon",
                 tint = Color.Gray,
-                modifier = Modifier.size(24.dp)
+                modifier = Modifier.size(24.dp).offset(x = (-20).dp, y = (2).dp)
             )
         }
     }

--- a/dodamduck_aos/app/src/main/java/org/chosun/dodamduck/ui/component/Text.kt
+++ b/dodamduck_aos/app/src/main/java/org/chosun/dodamduck/ui/component/Text.kt
@@ -158,14 +158,14 @@ fun DodamDuckTextT1(
 }
 
 @Composable
-fun EllipsisText(text: String, maxLength: Int) {
+fun EllipsisText(text: String, maxLength: Int, fontSize: Int) {
     val displayText = if (text.length > maxLength) {
         text.take(maxLength - 3) + "..."
     } else {
         text
     }
 
-    Text(text = displayText)
+    Text(text = displayText, fontSize = fontSize.sp)
 }
 
 @Composable

--- a/dodamduck_aos/app/src/main/java/org/chosun/dodamduck/ui/component/lazy_components/ToyLazy.kt
+++ b/dodamduck_aos/app/src/main/java/org/chosun/dodamduck/ui/component/lazy_components/ToyLazy.kt
@@ -10,7 +10,6 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.Card
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.unit.dp
 import androidx.compose.material3.Text
 import androidx.compose.foundation.Image
@@ -26,6 +25,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.sp
+import coil.compose.rememberAsyncImagePainter
 import org.chosun.dodamduck.R
 import org.chosun.dodamduck.model.dto.ToyInfo
 import org.chosun.dodamduck.ui.component.EllipsisText
@@ -80,8 +80,9 @@ fun ToyItem(toyInfo: ToyInfo) {
         ) {
             Text(text = toyInfo.addressStreet.split(" ")[0])
             Text(text = toyInfo.managementAgencyName)
+            val toyName = toyInfo.toyName.replace(" ", "")
             Image(
-                painter = painterResource(id = R.drawable.ic_toy_48),
+                painter = rememberAsyncImagePainter("http://sy2978.dothome.co.kr/library/${toyName}.jpg"),
                 contentDescription = null,
                 modifier = Modifier
                     .fillMaxWidth()
@@ -92,7 +93,7 @@ fun ToyItem(toyInfo: ToyInfo) {
                 horizontalArrangement = Arrangement.SpaceBetween,
                 verticalAlignment = Alignment.CenterVertically
             ) {
-                EllipsisText(text = toyInfo.toyName, maxLength = 8)
+                EllipsisText(text = toyInfo.toyName, maxLength = 10, fontSize = 10)
                 Text(text = toyInfo.area, fontSize = 10.sp)
             }
 
@@ -102,7 +103,7 @@ fun ToyItem(toyInfo: ToyInfo) {
                 verticalAlignment = Alignment.CenterVertically
             ) {
                 Text(text = toyInfo.ageGroup, fontSize = 10.sp)
-                Text(text = toyInfo.rentalFee, fontSize = 10.sp)
+                Text(text = "${toyInfo.rentalFee}원", fontSize = 10.sp)
             }
             OutlinedButton(
                 modifier = Modifier.align(Alignment.CenterHorizontally),

--- a/dodamduck_aos/app/src/main/res/values/strings.xml
+++ b/dodamduck_aos/app/src/main/res/values/strings.xml
@@ -33,7 +33,7 @@
     <string name="dummy_toy_item_name">손목 자연 딸랑이</string>
     <string name="dummy_toy_item_classification">조작/탐색</string>
     <string name="dummy_toy_item_age_limit">1개월 이상</string>
-    <string name="dummy_toy_item_price">500원</string>
+    <string name="dummy_toy_item_price">500</string>
     <string name="ask_rental">대여 문의</string>
     <string name="dummy_post_info_item">빛가람동 \u00B7 1일전 \u00B7 조회 434</string>
     <string name="writing">글 쓰기</string>


### PR DESCRIPTION
✓ 관련 이슈 번호
close #142 

---

❄️ 구현 내용
- 장난감 도서관 API 사진 적용
- SearchBar 배경색 변경 

---

📸 스크린샷 
 <table>
  <tr>
    <td><img width="300" src="https://github.com/DodamDuck/DodamDuck/assets/54762273/26a97b82-2914-4848-bf3d-258afd3c2563)"></td>
</td>
  </tr>
  <tr>
    <td align="center"><b> 장난감 도서관 화면</b></td>
  </tr>
</table>

