### PR TITLE
[AOS] feat: 게시글 삭제 기능 및 ViewModel, Screen 분리 

### DIFF
--- a/dodamduck_aos/app/src/main/java/org/chosun/dodamduck/model/data/DodamDuckData.kt
+++ b/dodamduck_aos/app/src/main/java/org/chosun/dodamduck/model/data/DodamDuckData.kt
@@ -3,5 +3,5 @@ package org.chosun.dodamduck.model.data
 import org.chosun.dodamduck.model.dto.LoginDTO
 
 object DodamDuckData {
-    var userInfo: LoginDTO? = null
+    lateinit var userInfo: LoginDTO
 }

--- a/dodamduck_aos/app/src/main/java/org/chosun/dodamduck/model/network/PostApiService.kt
+++ b/dodamduck_aos/app/src/main/java/org/chosun/dodamduck/model/network/PostApiService.kt
@@ -3,9 +3,11 @@ package org.chosun.dodamduck.model.network
 import org.chosun.dodamduck.model.dto.CategoryDTO
 import org.chosun.dodamduck.model.dto.PostDTO
 import org.chosun.dodamduck.model.dto.PostDetailResponse
+import retrofit2.http.DELETE
 import retrofit2.http.Field
 import retrofit2.http.FormUrlEncoded
 import retrofit2.http.GET
+import retrofit2.http.HTTP
 import retrofit2.http.POST
 import retrofit2.http.Query
 
@@ -40,5 +42,12 @@ interface PostApiService {
 
     @GET("Categories.php")
     suspend fun getCategories(): List<CategoryDTO>
+
+    @HTTP(method = "DELETE", path = "PostDelete.php", hasBody = true)
+    @FormUrlEncoded
+    suspend fun deletePost(
+        @Field("post_id") postId: String,
+        @Field("user_id") userId: String
+    ): DodamDuckResponse?
 
 }

--- a/dodamduck_aos/app/src/main/java/org/chosun/dodamduck/model/network/TradeApiService.kt
+++ b/dodamduck_aos/app/src/main/java/org/chosun/dodamduck/model/network/TradeApiService.kt
@@ -4,12 +4,15 @@ import okhttp3.MultipartBody
 import okhttp3.RequestBody
 import org.chosun.dodamduck.model.dto.PostDetailResponse
 import org.chosun.dodamduck.model.dto.Trade
+import retrofit2.http.DELETE
 import retrofit2.http.Field
 import retrofit2.http.FormUrlEncoded
 import retrofit2.http.GET
+import retrofit2.http.HTTP
 import retrofit2.http.Multipart
 import retrofit2.http.POST
 import retrofit2.http.Part
+import retrofit2.http.Query
 
 interface TradeApiService {
     @GET("Post.php")
@@ -45,6 +48,12 @@ interface TradeApiService {
     @FormUrlEncoded
     suspend fun uploadViews(
         @Field("post_id") postId: String
+    ): DodamDuckResponse
+    @HTTP(method = "DELETE", path = "PostDelete.php", hasBody = true)
+    @FormUrlEncoded
+    suspend fun deleteTrade(
+        @Field("post_id") postId: String,
+        @Field("user_id") userId: String
     ): DodamDuckResponse
 
 }

--- a/dodamduck_aos/app/src/main/java/org/chosun/dodamduck/model/repository/BasePostRepository.kt
+++ b/dodamduck_aos/app/src/main/java/org/chosun/dodamduck/model/repository/BasePostRepository.kt
@@ -17,4 +17,9 @@ interface BasePostRepository<ALL> {
     suspend fun uploadViewCount(
         postID: String
     ): DodamDuckResponse?
+
+    suspend fun deletePost(
+        postID: String,
+        userID: String
+    ): DodamDuckResponse?
 }

--- a/dodamduck_aos/app/src/main/java/org/chosun/dodamduck/model/repository/DummyItemFactory.kt
+++ b/dodamduck_aos/app/src/main/java/org/chosun/dodamduck/model/repository/DummyItemFactory.kt
@@ -3,10 +3,12 @@ package org.chosun.dodamduck.model.repository
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.res.painterResource
 import org.chosun.dodamduck.R
+import org.chosun.dodamduck.model.dto.PostCommentDTO
+import org.chosun.dodamduck.model.dto.PostDetailDTO
 import org.chosun.dodamduck.model.state.PostDetailUserInfoState
 
 object DummyItemFactory {
-    
+
     @Composable
     fun createPostDetailUserInfoDummyList(): List<PostDetailUserInfoState> {
         return listOf(
@@ -16,7 +18,7 @@ object DummyItemFactory {
                 info = "1일전",
                 content = "요새 걱정이 너무 많네요.. 도와주세요"
             ),
-            
+
             PostDetailUserInfoState(
                 userName = "유리 맘",
                 userProfile = painterResource(id = R.drawable.img_user_profile_2),
@@ -25,4 +27,31 @@ object DummyItemFactory {
             )
         )
     }
+
+    fun createPostDetailDto() = PostDetailDTO(
+        "다양한 보드게임 원합니다.",
+        "가족과 함께 즐길 수 있는 다양한 보드게임, 교환 원합니다.",
+        "http://sy2978.dothome.co.kr/uploads/post_id18.jpg",
+        "2023-11-12 17:49:15",
+        "인천",
+        "21",
+        "홍길동",
+        "user1",
+        "5",
+        "교환",
+        "http://sy2978.dothome.co.kr/uploads/post_id18.jpg"
+    )
+
+    fun createPostComment() = PostCommentDTO(
+        "1",
+        "1",
+        "user1",
+        "저랑 교환 하실래요?",
+        "2023-11-12 17:49:15",
+        "2023-11-12 17:49:15",
+        "김철수",
+        "2",
+        "광주 동명동",
+        ""
+    )
 }

--- a/dodamduck_aos/app/src/main/java/org/chosun/dodamduck/model/repository/PostRepository.kt
+++ b/dodamduck_aos/app/src/main/java/org/chosun/dodamduck/model/repository/PostRepository.kt
@@ -37,6 +37,10 @@ class PostRepository @Inject constructor(
         return service?.uploadViews(postID)
     }
 
+    override suspend fun deletePost(postID: String, userID: String): DodamDuckResponse? {
+        return service?.deletePost(postID, userID)
+    }
+
     suspend fun fetchCategories(): List<CategoryDTO>? {
         return service?.getCategories()
     }

--- a/dodamduck_aos/app/src/main/java/org/chosun/dodamduck/model/repository/TradeRepository.kt
+++ b/dodamduck_aos/app/src/main/java/org/chosun/dodamduck/model/repository/TradeRepository.kt
@@ -43,4 +43,8 @@ class TradeRepository @Inject constructor(
     override suspend fun uploadViewCount(postID: String): DodamDuckResponse? {
         return service?.uploadViews(postID)
     }
+
+    override suspend fun deletePost(postID: String, userID: String): DodamDuckResponse? {
+        return service?.deleteTrade(postID, userID)
+    }
 }

--- a/dodamduck_aos/app/src/main/java/org/chosun/dodamduck/model/viewmodel/AuthViewModel.kt
+++ b/dodamduck_aos/app/src/main/java/org/chosun/dodamduck/model/viewmodel/AuthViewModel.kt
@@ -28,8 +28,8 @@ class AuthViewModel @Inject constructor(
         val result = viewModelScope.async {
             val response = repository.requestLogin(userID, userPassword)
             _isLoginState.value = response?.login_success ?: false
-            DodamDuckData.userInfo = response
-            return@async response?.login_success ?: false
+            DodamDuckData.userInfo = response!!
+            return@async response.login_success ?: false
         }
         return result.await()
     }

--- a/dodamduck_aos/app/src/main/java/org/chosun/dodamduck/model/viewmodel/BasePostViewModel.kt
+++ b/dodamduck_aos/app/src/main/java/org/chosun/dodamduck/model/viewmodel/BasePostViewModel.kt
@@ -18,6 +18,9 @@ abstract class BasePostViewModel<ALL>(
     private val _postDetail = MutableStateFlow<PostDetailResponse?>(null)
     val postDetail: StateFlow<PostDetailResponse?> = _postDetail
 
+    private val _deletePostError = MutableStateFlow<Boolean>(false)
+    val deletePostError: StateFlow<Boolean> = _deletePostError
+
     fun fetchLists() {
         viewModelScope.launch {
             _postLists.value = repository.fetchList()
@@ -42,7 +45,7 @@ abstract class BasePostViewModel<ALL>(
         viewModelScope.launch {
             val result = repository.uploadComment(postID, userID, comment)
 
-            if(result?.error == "false") {
+            if (result?.error == "false") {
                 fetchDetail(postID)
             }
         }
@@ -51,6 +54,16 @@ abstract class BasePostViewModel<ALL>(
     fun uploadViewCount(postID: String) {
         viewModelScope.launch {
             repository.uploadViewCount(postID)
+        }
+    }
+
+    fun deletePost(
+        postID: String,
+        userID: String
+    ) {
+        viewModelScope.launch {
+            val error = repository.deletePost(postID, userID)?.error
+            _deletePostError.value = error == "true"
         }
     }
 }

--- a/dodamduck_aos/app/src/main/java/org/chosun/dodamduck/model/viewmodel/BasePostViewModel.kt
+++ b/dodamduck_aos/app/src/main/java/org/chosun/dodamduck/model/viewmodel/BasePostViewModel.kt
@@ -2,6 +2,7 @@ package org.chosun.dodamduck.model.viewmodel
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import kotlinx.coroutines.async
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.launch
@@ -17,10 +18,6 @@ abstract class BasePostViewModel<ALL>(
 
     private val _postDetail = MutableStateFlow<PostDetailResponse?>(null)
     val postDetail: StateFlow<PostDetailResponse?> = _postDetail
-
-    private val _deletePostError = MutableStateFlow<Boolean>(false)
-    val deletePostError: StateFlow<Boolean> = _deletePostError
-
     fun fetchLists() {
         viewModelScope.launch {
             _postLists.value = repository.fetchList()
@@ -57,13 +54,14 @@ abstract class BasePostViewModel<ALL>(
         }
     }
 
-    fun deletePost(
+    suspend fun deletePost(
         postID: String,
         userID: String
-    ) {
-        viewModelScope.launch {
+    ): Boolean {
+        val result = viewModelScope.async() {
             val error = repository.deletePost(postID, userID)?.error
-            _deletePostError.value = error == "true"
+            return@async error != "true"
         }
+        return result.await()
     }
 }

--- a/dodamduck_aos/app/src/main/java/org/chosun/dodamduck/ui/PostDetail.kt
+++ b/dodamduck_aos/app/src/main/java/org/chosun/dodamduck/ui/PostDetail.kt
@@ -1,24 +1,28 @@
 package org.chosun.dodamduck.ui
 
-import  androidx.compose.foundation.Image
+import androidx.compose.foundation.Image
 import androidx.compose.foundation.ScrollState
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.wrapContentHeight
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.Divider
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.KeyboardArrowLeft
+import androidx.compose.material.icons.filled.MoreVert
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
@@ -29,6 +33,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment.Companion.Bottom
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
@@ -50,6 +55,8 @@ import org.chosun.dodamduck.model.repository.DummyItemFactory
 import org.chosun.dodamduck.model.viewmodel.BasePostViewModel
 import org.chosun.dodamduck.model.viewmodel.PostViewModel
 import org.chosun.dodamduck.model.viewmodel.TradeViewModel
+import org.chosun.dodamduck.ui.component.BottomSheet
+import org.chosun.dodamduck.ui.component.BottomSheetText
 import org.chosun.dodamduck.ui.component.CommentIcon
 import org.chosun.dodamduck.ui.component.DodamDuckMessageInputField
 import org.chosun.dodamduck.ui.component.DodamDuckText
@@ -106,6 +113,14 @@ fun PostDetailContent(
     onSendButtonClick: () -> Unit,
     onTextFieldChange: (String) -> Unit = {}
 ) {
+    var showBottomSheet by remember { mutableStateOf(false) }
+
+    if (showBottomSheet) {
+        BottomSheet(onDismissRequest = { showBottomSheet = false }) {
+            PostDetailBottomSheetContent()
+        }
+    }
+
     Box(
         modifier = Modifier
             .fillMaxSize()
@@ -126,15 +141,25 @@ fun PostDetailContent(
                     .weight(1f)
                     .verticalScroll(scrollState)
             ) {
-
-                PostType(
-                    modifier = Modifier.padding(top = 10.dp, start = 10.dp),
-                    horizontalPadding = 25.dp,
-                    verticalPadding = 8.dp,
-                    text = "${postDetail?.post?.categoryName}",
-                    fontSize = 15,
-                    fontWeight = FontWeight.SemiBold
-                )
+                Row(modifier = Modifier.fillMaxWidth()) {
+                    PostType(
+                        modifier = Modifier.padding(top = 10.dp, start = 10.dp),
+                        horizontalPadding = 25.dp,
+                        verticalPadding = 8.dp,
+                        text = "${postDetail?.post?.categoryName}",
+                        fontSize = 15,
+                        fontWeight = FontWeight.SemiBold
+                    )
+                    Spacer(modifier = Modifier.weight(1f))
+                    Icon(
+                        modifier = Modifier
+                            .align(Bottom)
+                            .size(30.dp)
+                            .clickable { showBottomSheet = true },
+                        imageVector = Icons.Default.MoreVert,
+                        contentDescription = "More Icon"
+                    )
+                }
 
                 PostDetailUserInfo(
                     modifier = Modifier.padding(start = 10.dp, top = 18.dp),
@@ -243,6 +268,22 @@ fun PostDetailComments(items: List<PostCommentDTO>) {
             userInfo = "${item.location.split(" ")[1]} · ${item.verification_count}회 · ${item.created_at.formatDateDiff()}",
             postContent = item.content
         )
+    }
+}
+
+@Composable
+fun PostDetailBottomSheetContent() {
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .wrapContentHeight(),
+        verticalArrangement = Arrangement.Center
+    ) {
+        BottomSheetText(text = "수정")
+        Divider(modifier = Modifier.padding(vertical = 12.dp))
+        BottomSheetText(text = "삭제")
+        Divider(modifier = Modifier.padding(vertical = 12.dp))
+        BottomSheetText(modifier = Modifier.padding(bottom = 12.dp), "닫기")
     }
 }
 

--- a/dodamduck_aos/app/src/main/java/org/chosun/dodamduck/ui/PostDetail.kt
+++ b/dodamduck_aos/app/src/main/java/org/chosun/dodamduck/ui/PostDetail.kt
@@ -1,6 +1,7 @@
 package org.chosun.dodamduck.ui
 
 import  androidx.compose.foundation.Image
+import androidx.compose.foundation.ScrollState
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
@@ -44,6 +45,8 @@ import coil.compose.rememberAsyncImagePainter
 import org.chosun.dodamduck.R
 import org.chosun.dodamduck.model.data.DodamDuckData
 import org.chosun.dodamduck.model.dto.PostCommentDTO
+import org.chosun.dodamduck.model.dto.PostDetailResponse
+import org.chosun.dodamduck.model.repository.DummyItemFactory
 import org.chosun.dodamduck.model.viewmodel.BasePostViewModel
 import org.chosun.dodamduck.model.viewmodel.PostViewModel
 import org.chosun.dodamduck.model.viewmodel.TradeViewModel
@@ -76,6 +79,33 @@ fun PostDetailScreen(
     }
 
     val scrollState = rememberScrollState()
+
+    PostDetailContent(
+        navController = navController,
+        postDetail = postDetail,
+        commentText = commentText,
+        scrollState = scrollState,
+        onSendButtonClick = {
+            viewModel.uploadComment(
+                postId,
+                DodamDuckData.userInfo!!.userID,
+                commentText
+            )
+            commentText = ""
+        },
+        onTextFieldChange = { commentText = it }
+    )
+}
+
+@Composable
+fun PostDetailContent(
+    navController: NavController,
+    postDetail: PostDetailResponse?,
+    commentText: String,
+    scrollState: ScrollState,
+    onSendButtonClick: () -> Unit,
+    onTextFieldChange: (String) -> Unit = {}
+) {
     Box(
         modifier = Modifier
             .fillMaxSize()
@@ -159,15 +189,8 @@ fun PostDetailScreen(
             Divider()
             DodamDuckMessageInputField(
                 modifier = Modifier.height(50.dp),
-                onSendButtonClick = {
-                    viewModel.uploadComment(
-                        postId,
-                        DodamDuckData.userInfo!!.userID,
-                        commentText
-                    )
-                    commentText = ""
-                },
-                onTextFieldChange = { commentText = it},
+                onSendButtonClick = onSendButtonClick,
+                onTextFieldChange = onTextFieldChange,
                 value = commentText
             )
         }
@@ -227,6 +250,15 @@ fun PostDetailComments(items: List<PostCommentDTO>) {
 @Composable
 fun PostDetailPreview() {
     DodamDuckTheme {
-        PostDetailScreen(rememberNavController(), postType = "post")
+        PostDetailContent(
+            navController = rememberNavController(),
+            postDetail = PostDetailResponse(
+                DummyItemFactory.createPostDetailDto(),
+                listOf(DummyItemFactory.createPostComment())
+            ),
+            commentText = "",
+            scrollState = rememberScrollState(),
+            onSendButtonClick = { /*TODO*/ }
+        )
     }
 }

--- a/dodamduck_aos/app/src/main/java/org/chosun/dodamduck/ui/TradeWrite.kt
+++ b/dodamduck_aos/app/src/main/java/org/chosun/dodamduck/ui/TradeWrite.kt
@@ -42,6 +42,7 @@ import androidx.navigation.compose.rememberNavController
 import okhttp3.MediaType.Companion.toMediaTypeOrNull
 import okhttp3.RequestBody.Companion.toRequestBody
 import org.chosun.dodamduck.R
+import org.chosun.dodamduck.model.data.DodamDuckData
 import org.chosun.dodamduck.model.viewmodel.TradeViewModel
 import org.chosun.dodamduck.ui.component.DodamDuckRadioButton
 import org.chosun.dodamduck.ui.component.DodamDuckText
@@ -70,8 +71,8 @@ fun TradeWriteScreen(
     val context = LocalContext.current
     var title by remember { mutableStateOf("") }
     var detailDescription by remember { mutableStateOf("") }
-    var tradeLocation by remember { mutableStateOf("") }
-    var transactionType by remember { mutableIntStateOf(0) }
+    var tradeLocation by remember { mutableStateOf(DodamDuckData.userInfo.location) }
+    var transactionType by remember { mutableIntStateOf(1) }
 
     Box(
         modifier = Modifier
@@ -98,7 +99,7 @@ fun TradeWriteScreen(
                     end = 12.dp,
                     top = 17.dp
                 ),
-                onValueChange = { transactionType = it}
+                onValueChange = { transactionType = it+1 }
             )
             TradeWriteInputText(
                 modifier = Modifier
@@ -118,7 +119,7 @@ fun TradeWriteScreen(
                 titleText = stringResource(R.string.desired_trading_location),
                 text = stringResource(R.string.dummy_item_location),
                 value = tradeLocation,
-                onValueChange = { tradeLocation = it+1 }
+                onValueChange = { tradeLocation = it }
             )
             PrimaryButton(
                 modifier = Modifier.fillMaxWidth(),
@@ -130,7 +131,16 @@ fun TradeWriteScreen(
                 shape = RoundedCornerShape(6.dp),
                 height = 80.dp,
                 onClick = {
-                    handleTradeUpload(tradeViewModel, context, imageList, "seyeong2", transactionType.toString(), title, detailDescription, tradeLocation)
+                    handleTradeUpload(
+                        tradeViewModel,
+                        context,
+                        imageList,
+                        DodamDuckData.userInfo.userID,
+                        transactionType.toString(),
+                        title,
+                        detailDescription,
+                        tradeLocation
+                    )
                     navController.popBackStack()
                 }
             )
@@ -220,7 +230,7 @@ fun TradeTransactionType(modifier: Modifier = Modifier, onValueChange: (Int) -> 
                     onSelect = {
                         selectedOption = option
                         onValueChange(index)
-                               },
+                    },
                 )
             }
         }
@@ -258,6 +268,13 @@ fun handleTradeUpload(
     val locationBody = tradeLocation.toRequestBody("text/plain".toMediaTypeOrNull())
     val filePart = imageList[0].uriToMultipartBody(context)
 
-    tradeViewModel.uploadTrade(userIdBody, categoryIdBody, titleBody, contentBody, locationBody, filePart)
+    tradeViewModel.uploadTrade(
+        userIdBody,
+        categoryIdBody,
+        titleBody,
+        contentBody,
+        locationBody,
+        filePart
+    )
 }
 

--- a/dodamduck_aos/app/src/main/java/org/chosun/dodamduck/ui/component/BottomSheet.kt
+++ b/dodamduck_aos/app/src/main/java/org/chosun/dodamduck/ui/component/BottomSheet.kt
@@ -2,13 +2,16 @@ package org.chosun.dodamduck.ui.component
 
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.ModalBottomSheet
-import androidx.compose.material3.rememberModalBottomSheetState
+import androidx.compose.material3.SheetState
 import androidx.compose.runtime.Composable
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
-fun BottomSheet(onDismissRequest: () -> Unit, content: @Composable () -> Unit) {
-    val sheetState = rememberModalBottomSheetState()
+fun BottomSheet(
+    sheetState: SheetState,
+    onDismissRequest: () -> Unit,
+    content: @Composable () -> Unit
+) {
     ModalBottomSheet(
         onDismissRequest = onDismissRequest,
         sheetState = sheetState

--- a/dodamduck_aos/app/src/main/java/org/chosun/dodamduck/ui/component/BottomSheet.kt
+++ b/dodamduck_aos/app/src/main/java/org/chosun/dodamduck/ui/component/BottomSheet.kt
@@ -1,0 +1,18 @@
+package org.chosun.dodamduck.ui.component
+
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.material3.rememberModalBottomSheetState
+import androidx.compose.runtime.Composable
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun BottomSheet(onDismissRequest: () -> Unit, content: @Composable () -> Unit) {
+    val sheetState = rememberModalBottomSheetState()
+    ModalBottomSheet(
+        onDismissRequest = onDismissRequest,
+        sheetState = sheetState
+    ) {
+        content()
+    }
+}

--- a/dodamduck_aos/app/src/main/java/org/chosun/dodamduck/ui/component/Text.kt
+++ b/dodamduck_aos/app/src/main/java/org/chosun/dodamduck/ui/component/Text.kt
@@ -265,13 +265,14 @@ fun ExampleUsage() {
 @Composable
 fun BottomSheetText(
     modifier: Modifier = Modifier,
-    text: String = ""
+    text: String = "",
+    color: Color = Color.Blue
 ) {
     Text(
         modifier = modifier.fillMaxWidth(),
         text = text,
         fontSize = 21.sp,
         textAlign = TextAlign.Center,
-        color = Color.Blue
+        color = color
     )
 }

--- a/dodamduck_aos/app/src/main/java/org/chosun/dodamduck/ui/component/Text.kt
+++ b/dodamduck_aos/app/src/main/java/org/chosun/dodamduck/ui/component/Text.kt
@@ -214,16 +214,34 @@ fun SpannableText(
             // 하이라이트되지 않은 텍스트의 시작 부분
             append(text.substring(0, startIndex))
             // 하이라이트 텍스트
-            withStyle(style = SpanStyle(color = highlightColor, fontSize = highlightFontSize, fontWeight = highlightFontWeight)) {
+            withStyle(
+                style = SpanStyle(
+                    color = highlightColor,
+                    fontSize = highlightFontSize,
+                    fontWeight = highlightFontWeight
+                )
+            ) {
                 append(highlightText)
             }
             // 하이라이트 뒤의 텍스트
-            withStyle(style = SpanStyle(color = defaultColor, fontSize = defaultFontSize, fontWeight = highlightFontWeight)) {
+            withStyle(
+                style = SpanStyle(
+                    color = defaultColor,
+                    fontSize = defaultFontSize,
+                    fontWeight = highlightFontWeight
+                )
+            ) {
                 append(text.substring(startIndex + highlightText.length))
             }
         } else {
             // 텍스트에 하이라이트할 부분이 없으면 모두 기본 스타일을 적용
-            withStyle(style = SpanStyle(color = defaultColor, fontSize = defaultFontSize, fontWeight = defaultFontWeight)) {
+            withStyle(
+                style = SpanStyle(
+                    color = defaultColor,
+                    fontSize = defaultFontSize,
+                    fontWeight = defaultFontWeight
+                )
+            ) {
                 append(text)
             }
         }
@@ -241,5 +259,19 @@ fun ExampleUsage() {
         highlightColor = Color(0xFF795548), // 갈색
         highlightFontSize = 20.sp,
         defaultFontSize = 16.sp
+    )
+}
+
+@Composable
+fun BottomSheetText(
+    modifier: Modifier = Modifier,
+    text: String = ""
+) {
+    Text(
+        modifier = modifier.fillMaxWidth(),
+        text = text,
+        fontSize = 21.sp,
+        textAlign = TextAlign.Center,
+        color = Color.Blue
     )
 }


### PR DESCRIPTION
✓ 관련 이슈 번호
close #144 

---

❄️ 구현 내용
- Screen, ViewModel을 분리하여 Preview가 동작 하도록 수정 
- Modal Bottom Sheet 구현
- 거래/나눔 삭제 API, 게시글 삭제 API 연동

---

📸 스크린샷 
 <table>
  <tr>
    <td><img width="300" src="https://github.com/DodamDuck/DodamDuck/assets/54762273/3866ee06-3839-4c0e-9f23-560eb103985f"></td>
    <td><img width="300" src="https://github.com/DodamDuck/DodamDuck/assets/54762273/24bcdde7-6ff8-4ee7-9413-f5d429f51eae"></td>
</td>
  </tr>
  <tr>
    <td align="center"><b> Bottom Sheet </b></td>
    <td align="center"><b> 거래/나눔 삭제 </b></td>
  </tr>


